### PR TITLE
Change 'read' to 'read_at'

### DIFF
--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -31,11 +31,16 @@ class NotificationController extends Controller
     {
         $user = $request->user();
 
-        $notifications = $user->unreadNotifications()
-            ->limit((int) $request->input('limit', 0))
-            ->get()->each(function ($n) {
-                $n->created = $n->created_at->toIso8601String();
-            });
+        // Limit the number of returned notifications, or return all
+        $query = $user->unreadNotifications();
+        $limit = (int) $request->input('limit', 0);
+        if ($limit) {
+            $query = $query->limit($limit);
+        }
+
+        $notifications = $query->get()->each(function ($n) {
+            $n->created = $n->created_at->toIso8601String();
+        });
 
         $total = $user->unreadNotifications->count();
 

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -149,7 +149,7 @@ class NotificationController extends Controller
             return response()->json('Notification not found.', 404);
         }
 
-        $notification->update(['read' => true]);
+        $notification->markAsRead();
 
         event(new NotificationRead($subscription->user->id, $id));
     }

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -88,7 +88,9 @@ class NotificationController extends Controller
     {
         $request->user()
                 ->unreadNotifications()
-                ->update(['read' => true]);
+                ->get()->each(function ($n) {
+                    $n->markAsRead();
+                });
 
         event(new NotificationReadAll($request->user()->id));
     }

--- a/database/migrations/2016_07_30_000002_create_notifications_table.php
+++ b/database/migrations/2016_07_30_000002_create_notifications_table.php
@@ -19,7 +19,7 @@ class CreateNotificationsTable extends Migration
             $table->string('notifiable_type');
             $table->integer('notifiable_id');
             $table->text('data');
-            $table->boolean('read');
+            $table->dateTime('read_at')->nullable();
             $table->timestamps();
 
             $table->index(['notifiable_type', 'notifiable_id']);


### PR DESCRIPTION
Looks like `Illuminate\Notifications\DatabaseNotification` uses a `read_at` datetime instead of a `read` bool. Updated migration to match.

There are a few other things that are still sending/expecting a `read` property (e.g. /notifications/mark-all-read). I'll try to find them all and add them to this PR.